### PR TITLE
Support standalone JRE

### DIFF
--- a/launcher-fancy/build.gradle
+++ b/launcher-fancy/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
     compile project(':launcher')
-    compile 'io.github.cottonmc.insubstantial:substance:7.3.1-SNAPSHOT'
+    compile 'io.github.cottonmc.insubstantial:substance:7.3.1-SNAPSHOT' // com.github.insubstantial:substance:7.3
 }
 
 shadowJar {

--- a/launcher/src/main/java/com/skcraft/launcher/launch/JavaRuntimeFinder.java
+++ b/launcher/src/main/java/com/skcraft/launcher/launch/JavaRuntimeFinder.java
@@ -41,6 +41,9 @@ public final class JavaRuntimeFinder {
             getEntriesFromRegistry(entries, "SOFTWARE\\JavaSoft\\Java Development Kit");
         } catch (Throwable ignored) {
         }
+        
+        // TODO: Check JAVA_HOME and JRE_HOME env vars.
+        
         Collections.sort(entries);
         
         if (entries.size() > 0) {

--- a/launcher/src/main/java/com/skcraft/launcher/launch/JavaRuntimeFinder.java
+++ b/launcher/src/main/java/com/skcraft/launcher/launch/JavaRuntimeFinder.java
@@ -39,10 +39,15 @@ public final class JavaRuntimeFinder {
         try {
             getEntriesFromRegistry(entries, "SOFTWARE\\JavaSoft\\Java Runtime Environment");
             getEntriesFromRegistry(entries, "SOFTWARE\\JavaSoft\\Java Development Kit");
-        } catch (Throwable ignored) {
-        }
+        } catch (Throwable ignored) { }
         
-        // TODO: Check JAVA_HOME and JRE_HOME env vars.
+        try {
+            JREEntry entry = new JREEntry();
+            entry.dir = new File(System.getProperty("java.home"), "bin/java.exe");
+            entry.version = System.getProperty("java.version");
+            entry.is64Bit = true;  // probem?
+            entries.add(entry);
+        } catch (Throwable ignored) { }
         
         Collections.sort(entries);
         


### PR DESCRIPTION
This zipped Java (lying near the launcher) should be supported:

https://www.openlogic.com/openjdk-downloads?field_java_parent_version_target_id=807&field_operating_system_target_id=436&field_architecture_target_id=391&field_java_package_target_id=401


If we make this work, it should be possible to redistribute JRE along with the launcher.